### PR TITLE
Create a sample set of data to ease development

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,8 +8,6 @@
 
 require 'csv'
 
-countries = CSV.read('lib/data/country.csv', headers: true)
-
-countries.each do |country|
+CSV.foreach('lib/data/country.csv', headers: true) do |country|
   Country.find_or_create_by!(code: country['id'], name: country['value'])
 end

--- a/lib/data/prime/directors.csv
+++ b/lib/data/prime/directors.csv
@@ -1,0 +1,11 @@
+name,country_code
+"Jean Renoir",FR
+"Jacques Tati",FR
+"Yasujirō Ozu",JP
+"Mikio Naruse",JP
+"Luis Buñuel",ES
+"Ernst Lubitsch",US
+"Alfred Hitchcock",GB
+"John Ford",US
+"Carl Theodor Dreyer",DK
+"Robert Bresson",FR

--- a/lib/data/prime/movies.csv
+++ b/lib/data/prime/movies.csv
@@ -1,0 +1,11 @@
+original_title,director_name,year
+"The River","Jean Renoir",1951
+Playtime,"Jacques Tati",1967
+Banshun,"Yasujirō Ozu",1949
+"Onna ga kaidan wo agaru toki","Mikio Naruse",1960
+"El ángel exterminador","Luis Buñuel",1962
+"Heaven Can Wait","Ernst Lubitsch",1943
+"Notorious","Alfred Hitchcock",1946
+"Young Mr. Lincoln","John Ford",1939
+"Vampyr","Carl Theodor Dreyer",1932
+"Journal d'un curé de campagne","Robert Bresson",1951

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,13 +1,31 @@
+require 'csv'
+
 if Rails.env.development? || Rails.env.staging?
   namespace :dev do
     desc "Seed data for development environment"
     task prime: "db:setup" do
-      User.create(
-        first_name: "John",
-        last_name: "Wayne",
-        email: "john@example.org",
-        password: "stagecoach"
-      )
+      if Rails.env.development?
+        User.create(
+          first_name: "John",
+          last_name: "Wayne",
+          email: "john@example.org",
+          password: "stagecoach"
+        )
+      end
+
+      CSV.foreach('lib/data/prime/directors.csv', headers: true) do |director|
+        Director.find_or_create_by!(
+          name: director['name'],
+          country: Country.find_by(code: director['country_code'])
+        )
+      end
+
+      CSV.foreach('lib/data/prime/movies.csv', headers: true) do |movie|
+        Movie.find_or_create_by!(
+          original_title: movie['original_title'],
+          directors: [Director.find_by(name: movie['director_name'])]
+        )
+      end
     end
   end
 end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -2,14 +2,14 @@ require 'csv'
 
 if Rails.env.development? || Rails.env.staging?
   namespace :dev do
-    desc "Seed data for development environment"
-    task prime: "db:setup" do
+    desc 'Seed data for development environment'
+    task prime: 'db:setup' do
       if Rails.env.development?
         User.create(
-          first_name: "John",
-          last_name: "Wayne",
-          email: "john@example.org",
-          password: "stagecoach"
+          first_name: 'John',
+          last_name: 'Wayne',
+          email: 'john@example.org',
+          password: 'stagecoach'
         )
       end
 

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -21,9 +21,10 @@ if Rails.env.development? || Rails.env.staging?
       end
 
       CSV.foreach('lib/data/prime/movies.csv', headers: true) do |movie|
+        director = Director.find_by!(name: movie['director_name'])
         Movie.find_or_create_by!(
           original_title: movie['original_title'],
-          directors: [Director.find_by(name: movie['director_name'])]
+          directors: [director]
         )
       end
     end


### PR DESCRIPTION
Add a couple of CSV's loaded by the `dev:prime` Rake task so that it's easy to have some basic data to work with.

Also, fix the seeds script to not read the whole CSV into a variable in memory. Instead, we must use `CSV`'s  "wrapped-`IO` interface" do use the records iteratively in a block, allowing the memory to be freed immediately after the last invocation of the block.