### PR TITLE
Cache gems in tests Github action

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,6 +1,6 @@
 name: RSpec
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   tests:
@@ -14,7 +14,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-        options: --health-cmd pg_isready --health-interval 10ms --health-timeout 500ms --health-retries 15
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gem-
+            ${{ runner.os }}-gems-
 
       - name: Install gems
         run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -35,7 +35,6 @@ jobs:
 
       - name: Install gems
         run: |
-          gem install bundler:1.17.3
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -3,42 +3,50 @@ name: RSpec
 on: [pull_request]
 
 jobs:
-  build:
+  tests:
+    name: Tests
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:11
+        image: postgres:11-alpine
         ports:
           - 5432:5432
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        options: --health-cmd pg_isready --health-interval 10ms --health-timeout 500ms --health-retries 15
     steps:
+      - name: Checkout code
       - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
 
       - name: Install dependent libraries
         run: sudo apt-get install libpq-dev
 
-      - name: Bundle install
+      - name: Ruby gem cache
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Install gems
         run: |
           gem install bundler:1.17.3
           bundle install --jobs 4 --retry 3
 
-      - name: Setup Database
+      - name: Setup test database
+        env:
+          env:
+          RAILS_ENV: test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
         run: |
-          cp config/database.yml.github-actions config/database.yml
-          bundle exec rake db:create
-          bundle exec rake db:schema:load
-        env:
-          RAILS_ENV: test
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          bin/rails db:setup
 
-      - name: Run RSpec
-        run: bundle exec rspec  --require rails_helper
-        env:
-          RAILS_ENV: test
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+      - name: Run RSpec tests
+        run: bundle exec rspec --require rails_helper
+

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -14,7 +14,11 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -40,7 +40,6 @@ jobs:
 
       - name: Setup test database
         env:
-          env:
           RAILS_ENV: test
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -45,8 +45,13 @@ jobs:
           POSTGRES_PASSWORD: postgres
         run: |
           cp config/database.yml.github-actions config/database.yml
-          bin/rails db:create db:schema:load
+          bundle exec rails db:create db:schema:load
 
       - name: Run RSpec tests
-        run: bundle exec rspec --require rails_helper
+        env:
+          RAILS_ENV: test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        run: |
+          bundle exec rspec --require rails_helper
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -58,4 +58,3 @@ jobs:
           POSTGRES_PASSWORD: postgres
         run: |
           bundle exec rspec --require rails_helper
-

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -33,9 +33,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gems-
+            ${{ runner.os }}-gem-
 
       - name: Install gems
         run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,6 +1,6 @@
 name: RSpec
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   tests:
@@ -25,13 +25,13 @@ jobs:
       - name: Install dependent libraries
         run: sudo apt-get install libpq-dev
 
-      - name: Ruby gem cache
+      - name: Cache gems
         uses: actions/cache@v1
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gems-
+            ${{ runner.os }}-gem-
 
       - name: Install gems
         run: |
@@ -45,7 +45,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
         run: |
-          bin/rails db:setup
+          bin/rails db:create db:setup
 
       - name: Run RSpec tests
         run: bundle exec rspec --require rails_helper

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -17,7 +17,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10ms --health-timeout 500ms --health-retries 15
     steps:
       - name: Checkout code
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v2
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Install gems
         run: |
           gem install bundler:1.17.3
+          bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
 
       - name: Setup test database

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -44,7 +44,8 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
         run: |
-          bin/rails db:create db:setup
+          cp config/database.yml.github-actions config/database.yml
+          bin/rails db:create db:schema:load
 
       - name: Run RSpec tests
         run: bundle exec rspec --require rails_helper


### PR DESCRIPTION
This PR adds the takes advantage of the `cache` action to reduce the duration of the build.

Main changes:

* Add step to fetch gems from cache (or cache them, if no cache found);
* Change `postgres` image to a smaller one to reduce container build time;
* Improve formatting and step names