### PR TITLE
Require user confirmation on sign in

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,15 @@
 class UsersController < Clearance::UsersController
+  def create
+    @user = user_from_params
+    @user.email_confirmation_token = Clearance::Token.new
+
+    if @user.save
+      redirect_back_or url_after_create
+    else
+      render template: 'users/new'
+    end
+  end
+
   private
 
   def user_params

--- a/app/guards/confirmed_user_guard.rb
+++ b/app/guards/confirmed_user_guard.rb
@@ -1,13 +1,11 @@
 class ConfirmedUserGuard < Clearance::SignInGuard
   def call
-    if user_confirmed?
+    if !signed_in?
+      next_guard
+    elsif current_user.email_confirmed_at.present?
       next_guard
     else
       failure 'You must be confirmed to sign in. Please check your e-mail.'
     end
-  end
-
-  def user_confirmed?
-    signed_in? && current_user.email_confirmed_at.present?
   end
 end

--- a/app/guards/confirmed_user_guard.rb
+++ b/app/guards/confirmed_user_guard.rb
@@ -1,0 +1,13 @@
+class ConfirmedUserGuard < Clearance::SignInGuard
+  def call
+    if user_confirmed?
+      next_guard
+    else
+      failure 'You must be confirmed to sign in. Please check your e-mail.'
+    end
+  end
+
+  def user_confirmed?
+    signed_in? && current_user.email_confirmed_at.present?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,6 @@ class User < ApplicationRecord
   end
 
   def confirm_email
-    self.email_confirmed_at = Time.current
-    save
+    update(email_confirmed_at: DateTime.now)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,4 +16,9 @@ class User < ApplicationRecord
   def full_name
     "#{first_name} #{last_name}"
   end
+
+  def confirm_email
+    self.email_confirmed_at = Time.current
+    save
+  end
 end

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -2,4 +2,5 @@ Clearance.configure do |config|
   config.mailer_sender = "reply@example.com"
   config.rotate_csrf_on_sign_in = true
   config.routes = true
+  config.sign_in_guards = [ConfirmedUserGuard]
 end

--- a/db/migrate/20210205165526_add_confirmed_at_to_users.rb
+++ b/db/migrate/20210205165526_add_confirmed_at_to_users.rb
@@ -1,0 +1,6 @@
+class AddConfirmedAtToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :email_confirmation_token, :string, null: false, default: ""
+    add_column :users, :email_confirmed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_01_180539) do
+ActiveRecord::Schema.define(version: 2021_02_05_165526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,6 +99,8 @@ ActiveRecord::Schema.define(version: 2020_04_01_180539) do
     t.string "encrypted_password", limit: 128
     t.string "confirmation_token", limit: 128
     t.string "remember_token", limit: 128
+    t.string "email_confirmation_token", default: "", null: false
+    t.datetime "email_confirmed_at"
     t.index ["country_id"], name: "index_users_on_country_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["remember_token"], name: "index_users_on_remember_token"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     first_name { 'John' }
     last_name { 'Doe' }
     password { 'password-1234' }
+
+    trait :confirmed do
+      email_confirmed_at { DateTime.now }
+    end
   end
 end

--- a/spec/features/rounds/user_checks_round_movie_as_seen_spec.rb
+++ b/spec/features/rounds/user_checks_round_movie_as_seen_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'User checks round movie as seen' do
-  given(:user) { create(:user) }
+  given(:user) { create(:user, :confirmed) }
   given(:team) { create(:team, name: 'Some team') }
   given(:round) { create(:round, user: user) }
 

--- a/spec/features/rounds/user_creates_a_new_round_spec.rb
+++ b/spec/features/rounds/user_creates_a_new_round_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'User triggers the creation of a new round' do
-  given(:user) { create(:user) }
+  given(:user) { create(:user, :confirmed) }
 
   background do
     user.teams << create(:team, name: 'Some team')

--- a/spec/features/sessions/user_signs_in_spec.rb
+++ b/spec/features/sessions/user_signs_in_spec.rb
@@ -1,11 +1,9 @@
 require 'rails_helper'
 
 feature 'User signs in' do
-  background do
-    create(:user, email: 'johndoe@example.org', password: 'password')
-  end
-
   scenario 'they see the sign out button if sign in succeeded' do
+    create(:user, :confirmed, email: 'johndoe@example.org', password: 'password')
+
     visit sign_in_path
 
     fill_in 'Email', with: 'johndoe@example.org'
@@ -15,7 +13,22 @@ feature 'User signs in' do
     expect(page).to have_content 'Sign out'
   end
 
-  scenario 'they see an error message if sign in failed' do
+  scenario 'they see an error message if they are not confirmed' do
+    create(:user, email: 'johndoe@example.org', password: 'password')
+
+    visit sign_in_path
+
+    fill_in 'Email', with: 'johndoe@example.org'
+    fill_in 'Password', with: 'password'
+    click_button 'Sign in'
+
+    expect(page).to have_content 'You must be confirmed to sign in. Please check your e-mail.'
+    expect(page).not_to have_content 'Sign out'
+  end
+
+  scenario 'they see an error message if sign in data is wrong' do
+    create(:user, :confirmed, email: 'johndoe@example.org', password: 'password')
+
     visit sign_in_path
 
     fill_in 'Email', with: 'johndoe@example.org'

--- a/spec/features/sessions/user_signs_out_spec.rb
+++ b/spec/features/sessions/user_signs_out_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'User signs out' do
   background do
-    user = create(:user)
+    user = create(:user, :confirmed)
     sign_in(user)
   end
 

--- a/spec/features/sessions/user_signs_up_spec.rb
+++ b/spec/features/sessions/user_signs_up_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'User signs up' do
-  scenario 'they are logged in after signing up' do
+  scenario 'they are created after signing up' do
     visit sign_up_path
 
     fill_in 'Email', with: 'user@example.org'
@@ -10,7 +10,7 @@ feature 'User signs up' do
     fill_in 'Password', with: 'password'
     click_button 'Sign up'
 
-    expect(page).to have_content 'Sign out'
+    expect(User.count).to eq 1
   end
 
   scenario 'they are not logged in if sign up fails' do

--- a/spec/features/teams/user_creates_a_team_spec.rb
+++ b/spec/features/teams/user_creates_a_team_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'User creates a team' do
   background do
-    user = create(:user)
+    user = create(:user, :confirmed)
     sign_in(user)
   end
 

--- a/spec/features/teams/user_joins_a_team_spec.rb
+++ b/spec/features/teams/user_joins_a_team_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'User joins an existing team' do
-  given(:user) { create(:user) }
+  given(:user) { create(:user, :confirmed) }
 
   background do
     sign_in(user)

--- a/spec/features/teams/user_leaves_a_team_spec.rb
+++ b/spec/features/teams/user_leaves_a_team_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'User leaves one of his teams' do
-  given(:user) { create(:user) }
+  given(:user) { create(:user, :confirmed) }
 
   background do
     user.teams << create(:team, name: 'Some team')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe User, type: :model do
 
   describe '#confirm_email' do
     let(:user) { build(:user, first_name: 'John', last_name: 'Doe') }
-    let(:fake_date)  { DateTime.new(2021, 1, 1, 12) }
+    let(:fake_date) { DateTime.new(2021, 1, 1, 12) }
 
     before { travel_to fake_date }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,4 +36,25 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#full_name' do
+    let(:user) { build(:user, first_name: 'John', last_name: 'Doe') }
+
+    it 'returns the first name and last name concatenated' do
+      expect(user.full_name).to eq 'John Doe'
+    end
+  end
+
+  describe '#confirm_email' do
+    let(:user) { build(:user, first_name: 'John', last_name: 'Doe') }
+    let(:fake_date)  { DateTime.new(2021, 1, 1, 12) }
+
+    before { travel_to fake_date }
+
+    it 'sets email_confirmed_at to the current date and time' do
+      user.confirm_email
+
+      expect(user.email_confirmed_at).to eq fake_date
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,6 +23,7 @@ end
 
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
+  config.include ActiveSupport::Testing::TimeHelpers
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/requests/rounds_api_spec.rb
+++ b/spec/requests/rounds_api_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe 'Rounds API', type: :request do
   describe 'POST /teams/:id/rounds' do
     let(:team) { create(:team) }
-    let(:user) { create(:user) }
+    let(:user) { create(:user, :confirmed) }
 
     context 'when team and user are valid' do
       it "creates a round for the authenticated user and redirects to the round's show page" do


### PR DESCRIPTION
This pull request adds a feature to require users to confirm their e-mail before being able to sign in.

Sending the e-mail with a confirmation URL is out of the scope of this pull request, and should be done separately.