### PR TITLE
Add admin column users and perform some other data model refinements

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,6 @@ class User < ApplicationRecord
   end
 
   def confirm_email
-    update(email_confirmed_at: DateTime.now)
+    update(email_confirmed_at: Time.current)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
-  def confirm_email
+  def confirm_email!
     update(email_confirmed_at: Time.current)
   end
 end

--- a/db/migrate/20210205165526_add_confirmed_at_to_users.rb
+++ b/db/migrate/20210205165526_add_confirmed_at_to_users.rb
@@ -1,6 +1,10 @@
 class AddConfirmedAtToUsers < ActiveRecord::Migration[5.2]
   def change
-    add_column :users, :email_confirmation_token, :string, null: false, default: ""
-    add_column :users, :email_confirmed_at, :datetime
+    change_table :users do |t|
+      t.string :email_confirmation_token, null: false, default: ""
+      t.datetime :email_confirmed_at
+      t.index :email_confirmation_token
+      t.index :email_confirmed_at
+    end
   end
 end

--- a/db/migrate/20210208205840_add_admin_to_users.rb
+++ b/db/migrate/20210208205840_add_admin_to_users.rb
@@ -1,0 +1,6 @@
+class AddAdminToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :admin, :boolean, null: false, default: false
+    add_index :users, :admin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_05_165526) do
+ActiveRecord::Schema.define(version: 2021_02_08_205840) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -109,6 +109,8 @@ ActiveRecord::Schema.define(version: 2021_02_05_165526) do
     t.string "remember_token", limit: 128
     t.string "email_confirmation_token", default: "", null: false
     t.datetime "email_confirmed_at"
+    t.boolean "admin", default: false, null: false
+    t.index ["admin"], name: "index_users_on_admin"
     t.index ["country_id"], name: "index_users_on_country_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["remember_token"], name: "index_users_on_remember_token"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -113,6 +113,8 @@ ActiveRecord::Schema.define(version: 2021_02_08_205840) do
     t.index ["admin"], name: "index_users_on_admin"
     t.index ["country_id"], name: "index_users_on_country_id"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["email_confirmation_token"], name: "index_users_on_email_confirmation_token"
+    t.index ["email_confirmed_at"], name: "index_users_on_email_confirmed_at"
     t.index ["remember_token"], name: "index_users_on_remember_token"
   end
 

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -44,13 +44,16 @@ if Rails.env.development? || Rails.env.staging?
               first_name: 'John',
               last_name: 'Wayne',
               email: 'john@example.org',
-              password: 'filmpassword'
+              password: 'filmpassword',
+              email_confirmed_at: Time.current
             ),
             User.create(
               first_name: 'Maureen',
               last_name: "O'Hara",
               email: 'maureen@example.org',
-              password: 'filmpassword'
+              password: 'filmpassword',
+              admin: true,
+              email_confirmed_at: Time.current
             )
           ],
           rounds: [

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     password { 'password-1234' }
 
     trait :confirmed do
-      email_confirmed_at { DateTime.now }
+      email_confirmed_at { Time.current }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -45,14 +45,14 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#confirm_email' do
+  describe '#confirm_email!' do
     let(:user) { build(:user, first_name: 'John', last_name: 'Doe') }
     let(:fake_date) { DateTime.new(2021, 1, 1, 12) }
 
     before { travel_to fake_date }
 
     it 'sets email_confirmed_at to the current date and time' do
-      user.confirm_email
+      user.confirm_email!
 
       expect(user.email_confirmed_at).to eq fake_date
     end


### PR DESCRIPTION
Add a boolean column to the `users` table, called `admin`, that can be used in policies and other conditions on the application.

Also apply minor code changes and add a couple of indices.