### PR TITLE
Prevent external requests in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,4 +39,5 @@ end
 group :test do
   gem 'capybara'
   gem 'shoulda-matchers'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,8 @@ GEM
       railties (>= 5.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.6)
     diff-lcs (1.4.4)
     domain_name (0.5.20190701)
@@ -104,6 +106,7 @@ GEM
     hanami-utils (1.3.7)
       concurrent-ruby (~> 1.0)
       transproc (~> 1.0)
+    hashdiff (1.0.1)
     http (4.4.1)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -225,6 +228,7 @@ GEM
       rubocop (>= 0.90.0, < 2.0)
     ruby-progressbar (1.11.0)
     ruby_dep (1.5.0)
+    safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -269,6 +273,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -307,6 +315,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webmock
 
 RUBY VERSION
    ruby 2.6.6p146

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,9 +11,12 @@ require 'clearance/rspec'
 require 'capybara/rails'
 require 'capybara/rspec'
 require 'pundit/rspec'
+require 'webmock/rspec'
 
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 Dir[Rails.root.join('spec', 'helpers', '**', '*.rb')].each { |f| require f }
+
+WebMock.disable_net_connect!
 
 begin
   ActiveRecord::Migration.maintain_test_schema!


### PR DESCRIPTION
This pull request adds the `webmock` gem to allow us to prevent any external requests triggered while running the test suite:

```ruby
WebMock.disable_net_connect!
```

This will ensure that our tests aren't leaking any external API calls without our knowledge. 