### PR TITLE
Install rails-erd

### DIFF
--- a/.erdconfig
+++ b/.erdconfig
@@ -1,0 +1,10 @@
+attributes:
+  - foreign_key
+  - inheritance
+warn: true
+title: The Cineclub app data model
+# exclude: null
+# only: null
+# only_recursion_depth: null
+# prepend_primary: false
+# cluster: false

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ Icon
 
 # Ignore the local-only version of .env which may contain sensitive data
 .env.local
+
+# Ignore the default output of the rails-erd gem
+erd.pdf

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :development do
   gem 'brakeman'
   gem 'bundler-audit'
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'rails-erd', require: false
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console', '>= 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    choice (0.2.0)
     clearance (2.3.0)
       actionmailer (>= 5.0)
       activemodel (>= 5.0)
@@ -175,6 +176,11 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
+    rails-erd (1.6.1)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     railties (5.2.4.5)
@@ -223,6 +229,8 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.90.0, < 2.0)
+    ruby-graphviz (1.2.5)
+      rexml
     ruby-progressbar (1.11.0)
     ruby_dep (1.5.0)
     sass (3.7.4)
@@ -297,6 +305,7 @@ DEPENDENCIES
   puma (~> 3.12)
   pundit (~> 2.1.0)
   rails (~> 5.2.4, >= 5.2.4.4)
+  rails-erd
   redis (~> 4.0)
   rspec-rails (~> 3.9)
   rubocop-rails


### PR DESCRIPTION
Add the rails-erd gem to the project's Gemfile -- only in the "development" group and without autoloading (`require: false`).

Also setup a default file whose options may be discussed in the future. These are just my personal preference to generate a simple, understandable diagram.

To generate output, you need to have the graphviz program installed on your machine (on a Mac: `brew install graphviz`) and then run, on the project's root, the `bundle exec erd` command. It will, by default, create a file in that same path with name `erd.pdf`. We set that file to be ignored by git.

An example with the current project tree (here converted to PNG):

![erd](https://user-images.githubusercontent.com/4856307/109208575-605c4880-77a2-11eb-8f8b-369a37ed3b6e.png)
