### PR TITLE
Remove `presence guard-clauses' from URL helpers

### DIFF
--- a/lib/external_urls.rb
+++ b/lib/external_urls.rb
@@ -3,14 +3,10 @@ module ExternalUrls
   TMDB_MOVIE_BASE_URL = 'https://www.themoviedb.org/movie'.freeze
 
   def imdb_movie_url(id)
-    return if id.nil?
-
     "#{IMDB_MOVIE_BASE_URL}/#{id}"
   end
 
   def tmdb_movie_url(id)
-    return if id.nil?
-
     "#{TMDB_MOVIE_BASE_URL}/#{id}"
   end
 


### PR DESCRIPTION
They don't make sense in regard with their interface.

These are pure functions that recieve a
numeric ID. That is a pre-condition and
it's the caller's responsability to
ensure it.