### PR TITLE
Calculate round "index" in team's rounds

### DIFF
--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -4,7 +4,7 @@ class Round < ApplicationRecord
   belongs_to :movie, optional: true
   has_many :screenings, dependent: :destroy
 
-  def number_in_team
-    team.rounds.order(created_at: :asc).where('created_at < ?', created_at).count + 1
+  def index
+    team.rounds.where('id < ?', id).count + 1
   end
 end

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -6,13 +6,10 @@ class Round < ApplicationRecord
 
   before_create :set_index_in_team
 
-  def set_index_in_team
-    self.index_in_team = next_index_in_team
-  end
-
   private
 
-  def next_index_in_team
-    (Round.where(team: team).order(:index_in_team).last&.index_in_team.to_i + 1) || 1
+  def set_index_in_team
+    last_round = Round.where(team: team).order(:index_in_team).last
+    self.index_in_team = last_round ? last_round.index_in_team + 1 : 1
   end
 end

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -3,4 +3,8 @@ class Round < ApplicationRecord
   belongs_to :team
   belongs_to :movie, optional: true
   has_many :screenings, dependent: :destroy
+
+  def number_in_team
+    team.rounds.order(created_at: :asc).where('created_at < ?', created_at).count + 1
+  end
 end

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -4,7 +4,15 @@ class Round < ApplicationRecord
   belongs_to :movie, optional: true
   has_many :screenings, dependent: :destroy
 
-  def index
-    team.rounds.where('id < ?', id).count + 1
+  before_create :set_index_in_team
+
+  def set_index_in_team
+    self.index_in_team = next_index_in_team
+  end
+
+  private
+
+  def next_index_in_team
+    (Round.where(team: team).order(:index_in_team).last&.index_in_team.to_i + 1) || 1
   end
 end

--- a/app/views/rounds/show.html.erb
+++ b/app/views/rounds/show.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col">
-    <h1>Round <%= @round.number_in_team %></h1>
+    <h1>Round <%= @round.index %></h1>
 
     <p><%= @round.user.full_name %>'s turn to pick the movie.</p>
 

--- a/app/views/rounds/show.html.erb
+++ b/app/views/rounds/show.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col">
-    <h1>Round <%= @round.id %></h1>
+    <h1>Round <%= @round.number_in_team %></h1>
 
     <p><%= @round.user.full_name %>'s turn to pick the movie.</p>
 

--- a/app/views/rounds/show.html.erb
+++ b/app/views/rounds/show.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col">
-    <h1>Round <%= @round.index %></h1>
+    <h1>Round <%= @round.index_in_team %></h1>
 
     <p><%= @round.user.full_name %>'s turn to pick the movie.</p>
 

--- a/db/migrate/20200108233217_create_rounds.rb
+++ b/db/migrate/20200108233217_create_rounds.rb
@@ -4,8 +4,11 @@ class CreateRounds < ActiveRecord::Migration[5.2]
       t.references :user, foreign_key: true, null: false
       t.references :team, foreign_key: true, null: false
       t.references :movie, foreign_key: true
+      t.integer :index_in_team, null: false
 
       t.timestamps
     end
+
+    add_index :rounds, [:team_id, :index_in_team], unique: true
   end
 end

--- a/db/migrate/20210309175446_add_index_in_team_to_rounds.rb
+++ b/db/migrate/20210309175446_add_index_in_team_to_rounds.rb
@@ -1,0 +1,6 @@
+class AddIndexInTeamToRounds < ActiveRecord::Migration[5.2]
+  def change
+    add_column :rounds, :index_in_team, :integer, null: false
+    add_index :rounds, [:team_id, :index_in_team], unique: true
+  end
+end

--- a/db/migrate/20210309175446_add_index_in_team_to_rounds.rb
+++ b/db/migrate/20210309175446_add_index_in_team_to_rounds.rb
@@ -1,6 +1,0 @@
-class AddIndexInTeamToRounds < ActiveRecord::Migration[5.2]
-  def change
-    add_column :rounds, :index_in_team, :integer, null: false
-    add_index :rounds, [:team_id, :index_in_team], unique: true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_09_175446) do
+ActiveRecord::Schema.define(version: 2021_02_08_205840) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,9 +72,9 @@ ActiveRecord::Schema.define(version: 2021_03_09_175446) do
     t.bigint "user_id", null: false
     t.bigint "team_id", null: false
     t.bigint "movie_id"
+    t.integer "index_in_team", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "index_in_team", null: false
     t.index ["movie_id"], name: "index_rounds_on_movie_id"
     t.index ["team_id", "index_in_team"], name: "index_rounds_on_team_id_and_index_in_team", unique: true
     t.index ["team_id"], name: "index_rounds_on_team_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_08_205840) do
+ActiveRecord::Schema.define(version: 2021_03_09_175446) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,7 +74,9 @@ ActiveRecord::Schema.define(version: 2021_02_08_205840) do
     t.bigint "movie_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "index_in_team", null: false
     t.index ["movie_id"], name: "index_rounds_on_movie_id"
+    t.index ["team_id", "index_in_team"], name: "index_rounds_on_team_id_and_index_in_team", unique: true
     t.index ["team_id"], name: "index_rounds_on_team_id"
     t.index ["user_id"], name: "index_rounds_on_user_id"
   end

--- a/spec/models/round_spec.rb
+++ b/spec/models/round_spec.rb
@@ -7,4 +7,18 @@ RSpec.describe Round, type: :model do
     it { should belong_to(:movie).optional }
     it { should have_many(:screenings) }
   end
+
+  describe '#number_in_team' do
+    let(:team) { create(:team) }
+
+    it "returns the round's position in a team's context according to its creation date" do
+      oldest_round = create(:round, team: team, created_at: 2.days.ago)
+      in_between_round = create(:round, team: team, created_at: 1.day.ago)
+      newest_round = create(:round, team: team)
+
+      expect(oldest_round.number_in_team).to eq 1
+      expect(in_between_round.number_in_team).to eq 2
+      expect(newest_round.number_in_team).to eq 3
+    end
+  end
 end

--- a/spec/models/round_spec.rb
+++ b/spec/models/round_spec.rb
@@ -10,15 +10,18 @@ RSpec.describe Round, type: :model do
 
   describe '#index' do
     let(:team) { create(:team) }
+    let(:another_team) { create(:team) }
 
     it "returns the round's position in a team's context according to its creation date" do
       first_round = create(:round, team: team)
       second_round = create(:round, team: team)
       third_round = create(:round, team: team)
+      another_teams_round = create(:round, team: another_team)
 
-      expect(first_round.index).to eq 1
-      expect(second_round.index).to eq 2
-      expect(third_round.index).to eq 3
+      expect(first_round.index_in_team).to eq 1
+      expect(second_round.index_in_team).to eq 2
+      expect(third_round.index_in_team).to eq 3
+      expect(another_teams_round.index_in_team).to eq 1
     end
   end
 end

--- a/spec/models/round_spec.rb
+++ b/spec/models/round_spec.rb
@@ -8,17 +8,17 @@ RSpec.describe Round, type: :model do
     it { should have_many(:screenings) }
   end
 
-  describe '#number_in_team' do
+  describe '#index' do
     let(:team) { create(:team) }
 
     it "returns the round's position in a team's context according to its creation date" do
-      oldest_round = create(:round, team: team, created_at: 2.days.ago)
-      in_between_round = create(:round, team: team, created_at: 1.day.ago)
-      newest_round = create(:round, team: team)
+      first_round = create(:round, team: team)
+      second_round = create(:round, team: team)
+      third_round = create(:round, team: team)
 
-      expect(oldest_round.number_in_team).to eq 1
-      expect(in_between_round.number_in_team).to eq 2
-      expect(newest_round.number_in_team).to eq 3
+      expect(first_round.index).to eq 1
+      expect(second_round.index).to eq 2
+      expect(third_round.index).to eq 3
     end
   end
 end


### PR DESCRIPTION
This pull request adds a new method to calculate a round's "index" in a team's context, since exposing the round's id might be misleading.